### PR TITLE
FIX #1 make RealmHelper.executeTransactionForRead enable to return value

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Dec 28 10:00:20 PST 2015
+#Mon Aug 08 11:56:55 JST 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/realm-java-helpers/build.gradle
+++ b/realm-java-helpers/build.gradle
@@ -35,6 +35,7 @@ android {
         targetSdkVersion 24
         versionCode 1
         versionName "0.0.3"
+        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
     buildTypes {
         release {
@@ -48,4 +49,9 @@ android {
 dependencies {
     compile 'io.reactivex:rxjava:1.1.7'
     compile 'com.google.code.gson:gson:2.7'
+
+    testCompile 'junit:junit:4.12'
+    androidTestCompile 'com.android.support:support-annotations:24.1.1'
+    androidTestCompile 'com.android.support.test:runner:0.5'
+    androidTestCompile 'com.android.support.test:rules:0.5'
 }

--- a/realm-java-helpers/src/androidTest/java/jp/co/crowdworks/realm_java_helpers/RealmHelperTest.java
+++ b/realm-java-helpers/src/androidTest/java/jp/co/crowdworks/realm_java_helpers/RealmHelperTest.java
@@ -1,0 +1,67 @@
+package jp.co.crowdworks.realm_java_helpers;
+
+import android.content.Context;
+import android.support.test.InstrumentationRegistry;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import io.realm.Realm;
+import io.realm.RealmConfiguration;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(JUnit4.class)
+public class RealmHelperTest {
+
+    @BeforeClass
+    public static void initializeRealm() {
+        Context context = InstrumentationRegistry.getContext();
+        RealmConfiguration config = new RealmConfiguration.Builder(context)
+                .name("test-"+System.currentTimeMillis()+".realm")
+                .build();
+
+        Realm.setDefaultConfiguration(config);
+
+        insertTestUsers();
+    }
+
+    private static void insertTestUsers() {
+        Realm realm = Realm.getDefaultInstance();
+        realm.executeTransaction(new Realm.Transaction() {
+            @Override
+            public void execute(Realm realm) {
+                realm.createOrUpdateObjectFromJson(TestUser.class, "{ id: 1, name: 'Nozomi' }");
+                realm.createOrUpdateObjectFromJson(TestUser.class, "{ id: 2, name: 'Hikari' }");
+                realm.createOrUpdateObjectFromJson(TestUser.class, "{ id: 3, name: 'Hayate' }");
+            }
+        });
+        realm.close();
+    }
+
+    @Test
+    public void testExecuteTransactionForRead() throws InterruptedException {
+        final TestUser user = RealmHelper.executeTransactionForRead(new RealmHelper.Transaction<TestUser>() {
+            @Override
+            public TestUser execute(Realm realm) {
+                TestUser u = realm.where(TestUser.class).equalTo("id", 2).findFirst();
+                assertEquals("Hikari",u.getName());
+                return u;
+            }
+        });
+        assertEquals("Hikari",user.getName());
+
+        // check if User is already detached from Realm
+        //  by accessing it from another thread.
+        new Thread() {
+            @Override
+            public void run() {
+                assertEquals(2, user.getId());
+            }
+        }.start();
+        Thread.sleep(1000);
+    }
+
+}

--- a/realm-java-helpers/src/androidTest/java/jp/co/crowdworks/realm_java_helpers/RealmHelperTest.java
+++ b/realm-java-helpers/src/androidTest/java/jp/co/crowdworks/realm_java_helpers/RealmHelperTest.java
@@ -12,6 +12,7 @@ import io.realm.Realm;
 import io.realm.RealmConfiguration;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 @RunWith(JUnit4.class)
 public class RealmHelperTest {
@@ -61,7 +62,20 @@ public class RealmHelperTest {
                 assertEquals(2, user.getId());
             }
         }.start();
+
         Thread.sleep(1000);
+    }
+
+    public void testExecuteTransactionForReadNull() {
+        final TestUser user = RealmHelper.executeTransactionForRead(new RealmHelper.Transaction<TestUser>() {
+            @Override
+            public TestUser execute(Realm realm) {
+                TestUser u = realm.where(TestUser.class).equalTo("id", 4).findFirst();
+                assertNull(u);
+                return u;
+            }
+        });
+        assertNull(user);
     }
 
 }

--- a/realm-java-helpers/src/androidTest/java/jp/co/crowdworks/realm_java_helpers/TestUser.java
+++ b/realm-java-helpers/src/androidTest/java/jp/co/crowdworks/realm_java_helpers/TestUser.java
@@ -1,0 +1,26 @@
+package jp.co.crowdworks.realm_java_helpers;
+
+import io.realm.RealmObject;
+import io.realm.annotations.PrimaryKey;
+
+public class TestUser extends RealmObject {
+    @PrimaryKey
+    private long id;
+    private String name;
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/realm-java-helpers/src/main/java/jp/co/crowdworks/realm_java_helpers/RealmHelper.java
+++ b/realm-java-helpers/src/main/java/jp/co/crowdworks/realm_java_helpers/RealmHelper.java
@@ -45,14 +45,23 @@ public class RealmHelper {
         return e;
     }
 
-    public static void executeTransactionForRead(Realm.Transaction transaction) {
+    public interface Transaction<T> {
+        T execute(Realm realm);
+    }
+
+    public static <T extends RealmObject> T executeTransactionForRead(Transaction<T> transaction) {
         Realm realm = get();
+
+        T object;
+
         try {
-            transaction.execute(realm);
+            object = RealmHelper.copyFromRealm(transaction.execute(realm));
         }
         finally {
             if (!realm.isClosed()) realm.close();
         }
+
+        return object;
     }
 
     public static Observable<Void> rxExecuteTransactionAsync(final Realm.Transaction transaction) {

--- a/realm-java-helpers/src/main/java/jp/co/crowdworks/realm_java_helpers/RealmHelper.java
+++ b/realm-java-helpers/src/main/java/jp/co/crowdworks/realm_java_helpers/RealmHelper.java
@@ -5,6 +5,7 @@ import com.google.gson.FieldAttributes;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
+import java.util.Collections;
 import java.util.List;
 
 import io.realm.Realm;
@@ -32,6 +33,8 @@ public class RealmHelper {
             .create();
 
     public static <E extends RealmObject> List<E> copyFromRealm(Iterable<E> objects) {
+        if (objects==null) return Collections.emptyList();
+
         Realm realm = get();
         List<E> l = realm.copyFromRealm(objects);
         if (!realm.isClosed()) realm.close();
@@ -39,6 +42,8 @@ public class RealmHelper {
     }
 
     public static <E extends RealmObject> E copyFromRealm(E object) {
+        if (object==null) return null;
+
         Realm realm = get();
         E e = realm.copyFromRealm(object);
         if (!realm.isClosed()) realm.close();


### PR DESCRIPTION
```
User u = RealmHelper.executeTransactionForRead(realm -> realm.where(User.class).equalsTo("id", 1));

Log.d(TAG, "username="+u.getName);

new Thread(){
  public void run() {
    // Since user is already detached from Realm,
    // you can also access to the model from another thread!
    Log.d(TAG, "username="+u.getName);
  }
}
```
